### PR TITLE
Add closing filter and UI theme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Map Enhancer Wizard** is a tool designed to enhance 2D Occupancy Grid maps, providing users with an easy way to improve the quality and usability of their maps through a user-friendly interface.
 
+Current features include thresholding, blurring, and morphological operations such as opening, closing, dilation, and erosion to correct common mapping artifacts.
+
 This is **version 1** of the tool. Future versions will include:
 
 - **Additional filters** for more versatile map enhancements


### PR DESCRIPTION
## Summary
- Enhance GUI styling by using the `clam` theme.
- Add configurable morphological closing filter to fill gaps in maps.
- Improve robustness with metadata read error handling and reset support.

## Testing
- `python -m py_compile code/map_enhancer_wizard.py`


------
https://chatgpt.com/codex/tasks/task_b_68aed09dd6308323928979b8dc5819e8