### PR TITLE
feat: autodetect point columns in 3D loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Map Enhancer Wizard (V1)
 
-**Map Enhancer Wizard** is a tool designed to enhance 2D Occupancy Grid maps, providing users with an easy way to improve the quality and usability of their maps through a user-friendly interface.
+**Map Enhancer Wizard** is a tool designed to enhance 2D Occupancy Grid maps and experimental 3D maps, providing users with an easy way to improve map quality through a user-friendly interface.
 
-Current features include thresholding, blurring, and morphological operations such as opening, closing, dilation, and erosion to correct common mapping artifacts.
+Current features include thresholding, blurring, and morphological operations such as opening, closing, dilation, and erosion to correct common mapping artifacts in 2D maps. A basic 3D viewer is also included that can load `.db` files containing point data.
 
 This is **version 1** of the tool. Future versions will include:
 
 - **Additional filters** for more versatile map enhancements
 - **Automation features** to streamline the enhancement process
 - **AI-powered enhancements** for intelligent map improvements
-- Support for **3D maps**
+- More advanced **3D map** processing
  
 ## Preview
 
@@ -23,11 +23,12 @@ To use this tool, you need to have the following Python packages installed:
 - pillow
 - pyyaml
 - numpy
+- matplotlib *(for the 3D viewer)*
 
 You can install these dependencies using **pip**:
 
 ```bash
-pip install opencv-python pillow pyyaml numpy
+pip install opencv-python pillow pyyaml numpy matplotlib
 ```
 
 ## Usage
@@ -35,14 +36,17 @@ pip install opencv-python pillow pyyaml numpy
 The main file to run is `map_enhancer_wizard.py`. To start the wizard, simply execute the following command in your **terminal**:
 
 ```bash
-python3 map_enhancer_wizard.py
+python3 code/map_enhancer_wizard.py
 ```
 
-Follow the on-screen **instructions** to load your 2D Occupancy Grid map and apply enhancements.
+After launching you can choose between the 2D and 3D modules.
 
-The wizard will guide you through the process of enhancing your map, allowing you to choose from available options and preview changes before saving.
-
-+ **Note:** Ensure your 2D Occupancy Grid map is in a compatible format. The tool expects a **.yaml** file along with its corresponding image file (e.g., **.pgm**). Basically, you’ll need to **double-click** and select the folder that **contains both** the .yaml and image file of your map.
+* For **2D maps**, ensure the selected folder contains a **.yaml** file along with its corresponding image file (e.g., **.pgm**).
+* For **3D maps**, simply provide a SQLite **.db** file. The viewer scans the
+  database for any table containing 3D coordinate columns (`x`, `y`, `z` or
+  `pose_x`, `pose_y`, `pose_z`) and builds a point cloud from it. This makes it
+  possible to load custom point databases as well as maps produced by
+  **RTAB‑Map**.
 
 ## Examples
 
@@ -62,7 +66,9 @@ Below are example collages demonstrating the enhancement results. Each collage i
 As this is version 1, there are some **limitations**:
 
 - Limited set of enhancement filters
-- Only supports 2D Occupancy Grid maps
+- 3D support is minimal and relies on finding coordinate columns in the
+  database; complex RTAB‑Map features like compressed scans are not yet
+  handled
 - No automation or AI features yet
 - May not handle very large maps efficiently
 

--- a/code/map_enhancer_2d.py
+++ b/code/map_enhancer_2d.py
@@ -1,0 +1,277 @@
+import tkinter as tk
+from tkinter import ttk, filedialog, messagebox
+from PIL import Image, ImageTk
+import cv2
+import numpy as np
+import yaml
+import os
+
+class ToolTip:
+    def __init__(self, widget, text):
+        self.widget = widget
+        self.text = text
+        self.tip_window = None
+        widget.bind("<Enter>", self.show_tip)
+        widget.bind("<Leave>", self.hide_tip)
+
+    def show_tip(self, event):
+        if self.tip_window or not self.text:
+            return
+        x, y = self.widget.winfo_rootx() + 25, self.widget.winfo_rooty() + 20
+        self.tip_window = tw = tk.Toplevel(self.widget)
+        tw.wm_overrideredirect(True)
+        tw.wm_geometry(f"+{x}+{y}")
+        label = tk.Label(tw, text=self.text, background="#ffffe0", relief=tk.SOLID, borderwidth=1, font=("Arial", 12))
+        label.pack()
+
+    def hide_tip(self, event):
+        if self.tip_window:
+            self.tip_window.destroy()
+            self.tip_window = None
+
+class MapEnhancer2D(tk.Tk):
+    """Tkinter application for enhancing 2D maps.
+
+    This class contains the original functionality of the project before
+    adding 3D map support. It has simply been renamed so that it can be
+    imported alongside the new 3D module.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.title("Map Enhancer Wizard 2D (V1)")
+        self.geometry("1200x800")
+        self.original_map = None
+        self.processed_map = None
+        self.map_metadata = None
+        self.original_folder_name = ""
+        self.zoom_factor = 1.0
+        self.pan_x = 0
+        self.pan_y = 0
+        self.init_ui()
+
+    def init_ui(self):
+        self.style = ttk.Style()
+        self.style.theme_use("clam")
+        self.style.configure("TButton", font=("Arial", 12, "bold"), foreground="red")
+        self.style.configure("TLabel", font=("Arial", 14, "bold"))
+
+        # Main frame with grid layout
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_columnconfigure(1, weight=3)
+        self.grid_rowconfigure(0, weight=1)
+
+        # Left: Controls frame
+        self.controls_frame = ttk.Frame(self, padding=10, relief=tk.RAISED)
+        self.controls_frame.grid(row=0, column=0, sticky="nsew")
+
+        # Right: Map preview canvas
+        self.canvas = tk.Canvas(self, bg="white", highlightthickness=1, highlightbackground="gray")
+        self.canvas.grid(row=0, column=1, sticky="nsew", padx=10, pady=10)
+
+        # Bottom: Status bar
+        self.status_frame = ttk.Frame(self, relief=tk.SUNKEN)
+        self.status_frame.grid(row=1, column=0, columnspan=2, sticky="ew")
+        self.status_label = ttk.Label(self.status_frame, text="Select a map folder to begin.")
+        self.status_label.pack(side=tk.LEFT, padx=5, pady=2)
+        self.progress = ttk.Progressbar(self.status_frame, mode="indeterminate", length=100)
+        self.progress.pack(side=tk.RIGHT, padx=5, pady=2)
+
+        # Controls frame content
+        #ttk.Label(self.controls_frame, text="Map Enhancer Controls", font=("Arial", 20, "bold")).pack(pady=(0, 10))
+
+        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
+        self.select_btn = ttk.Button(self.controls_frame, text="Select Map Folder", command=self.select_folder)
+        self.select_btn.pack(fill=tk.X, pady=5)
+        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
+
+        # Filter sliders
+        self.threshold_var = tk.DoubleVar(value=0.5)
+        self.threshold_slider = ttk.Scale(self.controls_frame, from_=0.0, to=1.0, variable=self.threshold_var, command=self.update_preview)
+        ttk.Label(self.controls_frame, text="Threshold (0-1)").pack(pady=5)
+        self.threshold_slider.pack(fill=tk.X, pady=10)
+        ToolTip(self.threshold_slider, "Binarize the map: lower values increase occupied areas.")
+        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
+
+        self.blur_var = tk.IntVar(value=0)
+        self.blur_slider = ttk.Scale(self.controls_frame, from_=0, to=5, variable=self.blur_var, command=self.update_preview)
+        ttk.Label(self.controls_frame, text="Blur Kernel Size").pack(pady=5)
+        self.blur_slider.pack(fill=tk.X, pady=10)
+        ToolTip(self.blur_slider, "Smooth noise with Gaussian blur.")
+        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
+
+        self.dilation_var = tk.IntVar(value=0)
+        self.dilation_slider = ttk.Scale(self.controls_frame, from_=0, to=10, variable=self.dilation_var, command=self.update_preview)
+        ttk.Label(self.controls_frame, text="Dilation Kernel Size").pack(pady=5)
+        self.dilation_slider.pack(fill=tk.X, pady=10)
+        ToolTip(self.dilation_slider, "Thicken obstacles for safer navigation.")
+        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
+
+        self.erosion_var = tk.IntVar(value=0)
+        self.erosion_slider = ttk.Scale(self.controls_frame, from_=0, to=10, variable=self.erosion_var, command=self.update_preview)
+        ttk.Label(self.controls_frame, text="Erosion Kernel Size").pack(pady=5)
+        self.erosion_slider.pack(fill=tk.X, pady=10)
+        ToolTip(self.erosion_slider, "Thin obstacles to refine the map.")
+        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
+
+        self.opening_var = tk.IntVar(value=0)
+        self.opening_slider = ttk.Scale(self.controls_frame, from_=0, to=5, variable=self.opening_var, command=self.update_preview)
+        ttk.Label(self.controls_frame, text="Opening Kernel Size").pack(pady=5)
+        self.opening_slider.pack(fill=tk.X, pady=10)
+        ToolTip(self.opening_slider, "Remove small objects/noise.")
+        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
+
+        self.closing_var = tk.IntVar(value=0)
+        self.closing_slider = ttk.Scale(self.controls_frame, from_=0, to=5, variable=self.closing_var, command=self.update_preview)
+        ttk.Label(self.controls_frame, text="Closing Kernel Size").pack(pady=5)
+        self.closing_slider.pack(fill=tk.X, pady=10)
+        ToolTip(self.closing_slider, "Fill small holes/gaps.")
+        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
+
+        # Buttons
+        self.save_btn = ttk.Button(self.controls_frame, text="Save Enhanced Map", command=self.save_map)
+        self.save_btn.pack(fill=tk.X, pady=10)
+        self.reset_btn = ttk.Button(self.controls_frame, text="Reset All Filters", command=self.reset_filters)
+        self.reset_btn.pack(fill=tk.X, pady=10)
+
+        # Bind events
+        self.bind("<Configure>", self.on_resize)
+        self.canvas.bind("<ButtonPress-1>", self.on_pan_start)
+        self.canvas.bind("<B1-Motion>", self.on_pan_move)
+        self.canvas.bind("<MouseWheel>", self.on_zoom)
+
+    def select_folder(self):
+        self.progress.start()
+        folder_path = filedialog.askdirectory()
+        if folder_path:
+            self.load_map(folder_path)
+        self.progress.stop()
+
+    def load_map(self, folder_path):
+        pgm_file = next((os.path.join(folder_path, f) for f in os.listdir(folder_path) if f.endswith(".pgm")), None)
+        yaml_file = next((os.path.join(folder_path, f) for f in os.listdir(folder_path) if f.endswith(".yaml")), None)
+        if not pgm_file or not yaml_file:
+            messagebox.showerror("Error", "Missing PGM or YAML file.")
+            return
+
+        try:
+            with open(yaml_file, 'r') as f:
+                self.map_metadata = yaml.safe_load(f)
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to read metadata: {e}")
+            return
+        self.original_map = cv2.imread(pgm_file, cv2.IMREAD_GRAYSCALE)
+        if self.original_map is None:
+            messagebox.showerror("Error", "Failed to load map.")
+            return
+
+        self.original_folder_name = os.path.basename(folder_path)
+        self.status_label.config(text=f"Map loaded: {self.original_folder_name}")
+        self.zoom_factor = 1.0
+        self.pan_x = 0
+        self.pan_y = 0
+        self.update_preview()
+
+    def apply_filters(self):
+        if self.original_map is None:
+            return
+        map_copy = self.original_map.copy()
+
+        # Blur
+        if (blur := self.blur_var.get()) > 0:
+            ksize = 2 * blur + 1
+            map_copy = cv2.GaussianBlur(map_copy, (ksize, ksize), 0)
+
+        # Threshold
+        thresh = self.threshold_var.get() * 255
+        map_copy = np.where(map_copy <= thresh, 0, 255).astype(np.uint8)
+
+        # Opening
+        if (opening := self.opening_var.get()) > 0:
+            kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (opening, opening))
+            map_copy = cv2.morphologyEx(map_copy, cv2.MORPH_OPEN, kernel)
+
+        # Closing
+        if (closing := self.closing_var.get()) > 0:
+            kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (closing, closing))
+            map_copy = cv2.morphologyEx(map_copy, cv2.MORPH_CLOSE, kernel)
+
+        # Dilation
+        if (dilation := self.dilation_var.get()) > 0:
+            kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (dilation, dilation))
+            map_copy = cv2.dilate(map_copy, kernel)
+
+        # Erosion
+        if (erosion := self.erosion_var.get()) > 0:
+            kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (erosion, erosion))
+            map_copy = cv2.erode(map_copy, kernel)
+
+        self.processed_map = map_copy
+
+    def update_preview(self, *args):
+        self.apply_filters()
+        if self.processed_map is not None:
+            canvas_width = self.canvas.winfo_width()
+            canvas_height = self.canvas.winfo_height()
+            map_height, map_width = self.processed_map.shape
+            scale = min(canvas_width / map_width, canvas_height / map_height) * self.zoom_factor
+            preview_width = int(map_width * scale)
+            preview_height = int(map_height * scale)
+            preview = cv2.resize(self.processed_map, (preview_width, preview_height), interpolation=cv2.INTER_NEAREST)
+            self.photo = ImageTk.PhotoImage(Image.fromarray(preview))
+            self.canvas.delete("all")
+            x = (canvas_width - preview_width) / 2 + self.pan_x
+            y = (canvas_height - preview_height) / 2 + self.pan_y
+            self.canvas.create_image(x, y, anchor=tk.NW, image=self.photo)
+
+    def on_resize(self, event):
+        self.update_preview()
+
+    def on_pan_start(self, event):
+        self.pan_start_x = event.x
+        self.pan_start_y = event.y
+
+    def on_pan_move(self, event):
+        delta_x = event.x - self.pan_start_x
+        delta_y = event.y - self.pan_start_y
+        self.pan_x += delta_x
+        self.pan_y += delta_y
+        self.pan_start_x = event.x
+        self.pan_start_y = event.y
+        self.update_preview()
+
+    def on_zoom(self, event):
+        scale = 1.1 if event.delta > 0 else 0.9
+        self.zoom_factor *= scale
+        self.update_preview()
+
+    def save_map(self):
+        if self.processed_map is None:
+            messagebox.showerror("Error", "No map to save.")
+            return
+        self.progress.start()
+        save_folder = filedialog.askdirectory()
+        if save_folder:
+            folder_name = os.path.basename(save_folder)
+            pgm_file = os.path.join(save_folder, f"{folder_name}.pgm")
+            yaml_file = os.path.join(save_folder, f"{folder_name}.yaml")
+            cv2.imwrite(pgm_file, self.processed_map)
+            self.map_metadata['image'] = f"{folder_name}.pgm"
+            with open(yaml_file, 'w') as f:
+                yaml.dump(self.map_metadata, f, default_flow_style=None, sort_keys=False)
+            self.status_label.config(text=f"Map saved to {save_folder}")
+            messagebox.showinfo("Success", "Map saved successfully.")
+        self.progress.stop()
+
+    def reset_filters(self):
+        self.threshold_var.set(0.5)
+        self.blur_var.set(0)
+        self.dilation_var.set(0)
+        self.erosion_var.set(0)
+        self.opening_var.set(0)
+        self.closing_var.set(0)
+        self.update_preview()
+
+if __name__ == "__main__":
+    app = MapEnhancer2D()
+    app.mainloop()

--- a/code/map_enhancer_3d.py
+++ b/code/map_enhancer_3d.py
@@ -1,0 +1,130 @@
+import tkinter as tk
+from tkinter import ttk, filedialog, messagebox
+import numpy as np
+import sqlite3
+from matplotlib.figure import Figure
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+
+class MapEnhancer3D(tk.Tk):
+    """Simple 3D map enhancer that works with SQLite `.db` files.
+
+    Rather than requiring a rigid schema, the loader now scans the database for
+    any table containing 3D coordinate columns. It first looks for a table with
+    `x`, `y`, `z` and optionally `value` columns. If those are not found, it
+    also checks for RTAB-Map style columns such as `pose_x`, `pose_y` and
+    `pose_z`. The detected columns are used to build a minimal point cloud which
+    can then be filtered by the threshold slider.
+
+    This is an intentionally lightweight visualisation intended as a starting
+    point for more advanced 3D enhancements."""
+
+    def __init__(self):
+        super().__init__()
+        self.title("Map Enhancer Wizard 3D (V1)")
+        self.geometry("1200x800")
+
+        self.points = None
+        self.filtered_points = None
+
+        self.init_ui()
+
+    def init_ui(self):
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_columnconfigure(1, weight=3)
+        self.grid_rowconfigure(0, weight=1)
+
+        # Controls frame on the left
+        self.controls_frame = ttk.Frame(self, padding=10, relief=tk.RAISED)
+        self.controls_frame.grid(row=0, column=0, sticky="nsew")
+
+        self.select_btn = ttk.Button(self.controls_frame, text="Select .db Map", command=self.select_file)
+        self.select_btn.pack(fill=tk.X, pady=5)
+
+        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
+
+        self.threshold_var = tk.DoubleVar(value=0.5)
+        ttk.Label(self.controls_frame, text="Threshold (0-1)").pack(pady=5)
+        self.threshold_slider = ttk.Scale(self.controls_frame, from_=0.0, to=1.0, variable=self.threshold_var, command=self.update_plot)
+        self.threshold_slider.pack(fill=tk.X, pady=10)
+
+        # Plot area on the right
+        self.figure = Figure()
+        self.ax = self.figure.add_subplot(111, projection='3d')
+        self.canvas_plot = FigureCanvasTkAgg(self.figure, master=self)
+        self.canvas_plot.get_tk_widget().grid(row=0, column=1, sticky="nsew", padx=10, pady=10)
+
+        # Status bar
+        self.status_frame = ttk.Frame(self, relief=tk.SUNKEN)
+        self.status_frame.grid(row=1, column=0, columnspan=2, sticky="ew")
+        self.status_label = ttk.Label(self.status_frame, text="Select a .db map to begin.")
+        self.status_label.pack(side=tk.LEFT, padx=5, pady=2)
+
+    def select_file(self):
+        file_path = filedialog.askopenfilename(filetypes=[("DB Files", "*.db"), ("All Files", "*.*")])
+        if file_path:
+            self.load_map(file_path)
+
+    def load_map(self, file_path):
+        try:
+            conn = sqlite3.connect(file_path)
+            cursor = conn.cursor()
+
+            table, cols = self._detect_point_table(cursor)
+            if table is None:
+                raise ValueError("No table with x/y/z coordinates found")
+
+            query = f"SELECT {cols[0]}, {cols[1]}, {cols[2]}"
+            if cols[3]:
+                query += f", {cols[3]}"
+            else:
+                query += ", 1.0"  # default intensity
+            query += f" FROM {table}"
+
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            conn.close()
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to read map data: {e}")
+            return
+
+        if not rows:
+            messagebox.showerror("Error", "No usable map data found in the database.")
+            return
+
+        self.points = np.array(rows, dtype=float)
+        self.status_label.config(text=f"Map loaded: {file_path}")
+        self.update_plot()
+
+    def _detect_point_table(self, cursor):
+        """Return a tuple (table_name, (x, y, z, value_col or None))."""
+
+        tables = [row[0] for row in cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+        for table in tables:
+            cols = [row[1].lower() for row in cursor.execute(f"PRAGMA table_info({table})")]
+            colset = set(cols)
+            if {'x', 'y', 'z', 'value'} <= colset:
+                return table, ('x', 'y', 'z', 'value')
+            if {'x', 'y', 'z'} <= colset:
+                return table, ('x', 'y', 'z', None)
+            if {'pose_x', 'pose_y', 'pose_z'} <= colset:
+                return table, ('pose_x', 'pose_y', 'pose_z', None)
+        return None, None
+
+    def apply_filters(self):
+        if self.points is None:
+            return
+        thresh = self.threshold_var.get()
+        mask = self.points[:, 3] <= thresh
+        self.filtered_points = self.points[mask]
+
+    def update_plot(self, *args):
+        self.apply_filters()
+        self.ax.clear()
+        if self.filtered_points is not None and len(self.filtered_points) > 0:
+            pts = self.filtered_points
+            self.ax.scatter(pts[:, 0], pts[:, 1], pts[:, 2], c=pts[:, 3], cmap='gray')
+        self.canvas_plot.draw()
+
+if __name__ == "__main__":
+    app = MapEnhancer3D()
+    app.mainloop()

--- a/code/map_enhancer_wizard.py
+++ b/code/map_enhancer_wizard.py
@@ -1,269 +1,30 @@
 import tkinter as tk
-from tkinter import ttk, filedialog, messagebox
-from PIL import Image, ImageTk
-import cv2
-import numpy as np
-import yaml
-import os
-
-class ToolTip:
-    def __init__(self, widget, text):
-        self.widget = widget
-        self.text = text
-        self.tip_window = None
-        widget.bind("<Enter>", self.show_tip)
-        widget.bind("<Leave>", self.hide_tip)
-
-    def show_tip(self, event):
-        if self.tip_window or not self.text:
-            return
-        x, y = self.widget.winfo_rootx() + 25, self.widget.winfo_rooty() + 20
-        self.tip_window = tw = tk.Toplevel(self.widget)
-        tw.wm_overrideredirect(True)
-        tw.wm_geometry(f"+{x}+{y}")
-        label = tk.Label(tw, text=self.text, background="#ffffe0", relief=tk.SOLID, borderwidth=1, font=("Arial", 12))
-        label.pack()
-
-    def hide_tip(self, event):
-        if self.tip_window:
-            self.tip_window.destroy()
-            self.tip_window = None
+from tkinter import ttk
+from map_enhancer_2d import MapEnhancer2D
+from map_enhancer_3d import MapEnhancer3D
 
 class MapEnhancerWizard(tk.Tk):
+    """Launcher window that lets the user pick between 2D and 3D modes."""
+
     def __init__(self):
         super().__init__()
-        self.title("Map Enhancer Wizard (V1)")
-        self.geometry("1200x800")
-        self.original_map = None
-        self.processed_map = None
-        self.map_metadata = None
-        self.original_folder_name = ""
-        self.zoom_factor = 1.0
-        self.pan_x = 0
-        self.pan_y = 0
+        self.title("Map Enhancer Wizard")
+        self.geometry("300x150")
         self.init_ui()
 
     def init_ui(self):
-        self.style = ttk.Style()
-        self.style.theme_use("clam")
-        self.style.configure("TButton", font=("Arial", 12, "bold"), foreground="red")
-        self.style.configure("TLabel", font=("Arial", 14, "bold"))
+        ttk.Button(self, text="2D Map Enhancer", command=self.launch_2d).pack(fill=tk.BOTH, expand=True, padx=20, pady=10)
+        ttk.Button(self, text="3D Map Enhancer", command=self.launch_3d).pack(fill=tk.BOTH, expand=True, padx=20, pady=10)
 
-        # Main frame with grid layout
-        self.grid_columnconfigure(0, weight=1)
-        self.grid_columnconfigure(1, weight=3)
-        self.grid_rowconfigure(0, weight=1)
+    def launch_2d(self):
+        self.destroy()
+        app = MapEnhancer2D()
+        app.mainloop()
 
-        # Left: Controls frame
-        self.controls_frame = ttk.Frame(self, padding=10, relief=tk.RAISED)
-        self.controls_frame.grid(row=0, column=0, sticky="nsew")
-
-        # Right: Map preview canvas
-        self.canvas = tk.Canvas(self, bg="white", highlightthickness=1, highlightbackground="gray")
-        self.canvas.grid(row=0, column=1, sticky="nsew", padx=10, pady=10)
-
-        # Bottom: Status bar
-        self.status_frame = ttk.Frame(self, relief=tk.SUNKEN)
-        self.status_frame.grid(row=1, column=0, columnspan=2, sticky="ew")
-        self.status_label = ttk.Label(self.status_frame, text="Select a map folder to begin.")
-        self.status_label.pack(side=tk.LEFT, padx=5, pady=2)
-        self.progress = ttk.Progressbar(self.status_frame, mode="indeterminate", length=100)
-        self.progress.pack(side=tk.RIGHT, padx=5, pady=2)
-
-        # Controls frame content
-        #ttk.Label(self.controls_frame, text="Map Enhancer Controls", font=("Arial", 20, "bold")).pack(pady=(0, 10))
-
-        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
-        self.select_btn = ttk.Button(self.controls_frame, text="Select Map Folder", command=self.select_folder)
-        self.select_btn.pack(fill=tk.X, pady=5)
-        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
-
-        # Filter sliders
-        self.threshold_var = tk.DoubleVar(value=0.5)
-        self.threshold_slider = ttk.Scale(self.controls_frame, from_=0.0, to=1.0, variable=self.threshold_var, command=self.update_preview)
-        ttk.Label(self.controls_frame, text="Threshold (0-1)").pack(pady=5)
-        self.threshold_slider.pack(fill=tk.X, pady=10)
-        ToolTip(self.threshold_slider, "Binarize the map: lower values increase occupied areas.")
-        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
-
-        self.blur_var = tk.IntVar(value=0)
-        self.blur_slider = ttk.Scale(self.controls_frame, from_=0, to=5, variable=self.blur_var, command=self.update_preview)
-        ttk.Label(self.controls_frame, text="Blur Kernel Size").pack(pady=5)
-        self.blur_slider.pack(fill=tk.X, pady=10)
-        ToolTip(self.blur_slider, "Smooth noise with Gaussian blur.")
-        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
-
-        self.dilation_var = tk.IntVar(value=0)
-        self.dilation_slider = ttk.Scale(self.controls_frame, from_=0, to=10, variable=self.dilation_var, command=self.update_preview)
-        ttk.Label(self.controls_frame, text="Dilation Kernel Size").pack(pady=5)
-        self.dilation_slider.pack(fill=tk.X, pady=10)
-        ToolTip(self.dilation_slider, "Thicken obstacles for safer navigation.")
-        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
-
-        self.erosion_var = tk.IntVar(value=0)
-        self.erosion_slider = ttk.Scale(self.controls_frame, from_=0, to=10, variable=self.erosion_var, command=self.update_preview)
-        ttk.Label(self.controls_frame, text="Erosion Kernel Size").pack(pady=5)
-        self.erosion_slider.pack(fill=tk.X, pady=10)
-        ToolTip(self.erosion_slider, "Thin obstacles to refine the map.")
-        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
-
-        self.opening_var = tk.IntVar(value=0)
-        self.opening_slider = ttk.Scale(self.controls_frame, from_=0, to=5, variable=self.opening_var, command=self.update_preview)
-        ttk.Label(self.controls_frame, text="Opening Kernel Size").pack(pady=5)
-        self.opening_slider.pack(fill=tk.X, pady=10)
-        ToolTip(self.opening_slider, "Remove small objects/noise.")
-        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
-
-        self.closing_var = tk.IntVar(value=0)
-        self.closing_slider = ttk.Scale(self.controls_frame, from_=0, to=5, variable=self.closing_var, command=self.update_preview)
-        ttk.Label(self.controls_frame, text="Closing Kernel Size").pack(pady=5)
-        self.closing_slider.pack(fill=tk.X, pady=10)
-        ToolTip(self.closing_slider, "Fill small holes/gaps.")
-        ttk.Separator(self.controls_frame, orient="horizontal").pack(fill=tk.X, pady=5)
-
-        # Buttons
-        self.save_btn = ttk.Button(self.controls_frame, text="Save Enhanced Map", command=self.save_map)
-        self.save_btn.pack(fill=tk.X, pady=10)
-        self.reset_btn = ttk.Button(self.controls_frame, text="Reset All Filters", command=self.reset_filters)
-        self.reset_btn.pack(fill=tk.X, pady=10)
-
-        # Bind events
-        self.bind("<Configure>", self.on_resize)
-        self.canvas.bind("<ButtonPress-1>", self.on_pan_start)
-        self.canvas.bind("<B1-Motion>", self.on_pan_move)
-        self.canvas.bind("<MouseWheel>", self.on_zoom)
-
-    def select_folder(self):
-        self.progress.start()
-        folder_path = filedialog.askdirectory()
-        if folder_path:
-            self.load_map(folder_path)
-        self.progress.stop()
-
-    def load_map(self, folder_path):
-        pgm_file = next((os.path.join(folder_path, f) for f in os.listdir(folder_path) if f.endswith(".pgm")), None)
-        yaml_file = next((os.path.join(folder_path, f) for f in os.listdir(folder_path) if f.endswith(".yaml")), None)
-        if not pgm_file or not yaml_file:
-            messagebox.showerror("Error", "Missing PGM or YAML file.")
-            return
-
-        try:
-            with open(yaml_file, 'r') as f:
-                self.map_metadata = yaml.safe_load(f)
-        except Exception as e:
-            messagebox.showerror("Error", f"Failed to read metadata: {e}")
-            return
-        self.original_map = cv2.imread(pgm_file, cv2.IMREAD_GRAYSCALE)
-        if self.original_map is None:
-            messagebox.showerror("Error", "Failed to load map.")
-            return
-
-        self.original_folder_name = os.path.basename(folder_path)
-        self.status_label.config(text=f"Map loaded: {self.original_folder_name}")
-        self.zoom_factor = 1.0
-        self.pan_x = 0
-        self.pan_y = 0
-        self.update_preview()
-
-    def apply_filters(self):
-        if self.original_map is None:
-            return
-        map_copy = self.original_map.copy()
-
-        # Blur
-        if (blur := self.blur_var.get()) > 0:
-            ksize = 2 * blur + 1
-            map_copy = cv2.GaussianBlur(map_copy, (ksize, ksize), 0)
-
-        # Threshold
-        thresh = self.threshold_var.get() * 255
-        map_copy = np.where(map_copy <= thresh, 0, 255).astype(np.uint8)
-
-        # Opening
-        if (opening := self.opening_var.get()) > 0:
-            kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (opening, opening))
-            map_copy = cv2.morphologyEx(map_copy, cv2.MORPH_OPEN, kernel)
-
-        # Closing
-        if (closing := self.closing_var.get()) > 0:
-            kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (closing, closing))
-            map_copy = cv2.morphologyEx(map_copy, cv2.MORPH_CLOSE, kernel)
-
-        # Dilation
-        if (dilation := self.dilation_var.get()) > 0:
-            kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (dilation, dilation))
-            map_copy = cv2.dilate(map_copy, kernel)
-
-        # Erosion
-        if (erosion := self.erosion_var.get()) > 0:
-            kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (erosion, erosion))
-            map_copy = cv2.erode(map_copy, kernel)
-
-        self.processed_map = map_copy
-
-    def update_preview(self, *args):
-        self.apply_filters()
-        if self.processed_map is not None:
-            canvas_width = self.canvas.winfo_width()
-            canvas_height = self.canvas.winfo_height()
-            map_height, map_width = self.processed_map.shape
-            scale = min(canvas_width / map_width, canvas_height / map_height) * self.zoom_factor
-            preview_width = int(map_width * scale)
-            preview_height = int(map_height * scale)
-            preview = cv2.resize(self.processed_map, (preview_width, preview_height), interpolation=cv2.INTER_NEAREST)
-            self.photo = ImageTk.PhotoImage(Image.fromarray(preview))
-            self.canvas.delete("all")
-            x = (canvas_width - preview_width) / 2 + self.pan_x
-            y = (canvas_height - preview_height) / 2 + self.pan_y
-            self.canvas.create_image(x, y, anchor=tk.NW, image=self.photo)
-
-    def on_resize(self, event):
-        self.update_preview()
-
-    def on_pan_start(self, event):
-        self.pan_start_x = event.x
-        self.pan_start_y = event.y
-
-    def on_pan_move(self, event):
-        delta_x = event.x - self.pan_start_x
-        delta_y = event.y - self.pan_start_y
-        self.pan_x += delta_x
-        self.pan_y += delta_y
-        self.pan_start_x = event.x
-        self.pan_start_y = event.y
-        self.update_preview()
-
-    def on_zoom(self, event):
-        scale = 1.1 if event.delta > 0 else 0.9
-        self.zoom_factor *= scale
-        self.update_preview()
-
-    def save_map(self):
-        if self.processed_map is None:
-            messagebox.showerror("Error", "No map to save.")
-            return
-        self.progress.start()
-        save_folder = filedialog.askdirectory()
-        if save_folder:
-            folder_name = os.path.basename(save_folder)
-            pgm_file = os.path.join(save_folder, f"{folder_name}.pgm")
-            yaml_file = os.path.join(save_folder, f"{folder_name}.yaml")
-            cv2.imwrite(pgm_file, self.processed_map)
-            self.map_metadata['image'] = f"{folder_name}.pgm"
-            with open(yaml_file, 'w') as f:
-                yaml.dump(self.map_metadata, f, default_flow_style=None, sort_keys=False)
-            self.status_label.config(text=f"Map saved to {save_folder}")
-            messagebox.showinfo("Success", "Map saved successfully.")
-        self.progress.stop()
-
-    def reset_filters(self):
-        self.threshold_var.set(0.5)
-        self.blur_var.set(0)
-        self.dilation_var.set(0)
-        self.erosion_var.set(0)
-        self.opening_var.set(0)
-        self.closing_var.set(0)
-        self.update_preview()
+    def launch_3d(self):
+        self.destroy()
+        app = MapEnhancer3D()
+        app.mainloop()
 
 if __name__ == "__main__":
     app = MapEnhancerWizard()


### PR DESCRIPTION
## Summary
- remove rigid `map_data` requirement in 3D viewer and auto-detect tables containing x/y/z or pose_x/pose_y/pose_z columns
- document new flexible `.db` loading including RTAB-Map compatibility and updated limitations

## Testing
- `python -m py_compile code/map_enhancer_2d.py code/map_enhancer_3d.py code/map_enhancer_wizard.py`


------
https://chatgpt.com/codex/tasks/task_b_68aed3bff6b08323819997933308ef3a